### PR TITLE
Add V^4 decomposition for C3X and C3SqrtX

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,6 @@
 * @Qiskit/terra-core
 
 # Qiskit folders (also their corresponding tests)
-circuit/              @Qiskit/terra-core @cryoris @ewinston @chriseclectic
-extensions/           @Qiskit/terra-core @cryoris @ewinston
-quantum_info/         @Qiskit/terra-core @chriseclectic @ewinston
 providers/            @Qiskit/terra-core @jyu00
 pulse/                @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli
 scheduler/            @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli

--- a/examples/python/ibmq/hello_quantum.py
+++ b/examples/python/ibmq/hello_quantum.py
@@ -55,8 +55,10 @@ ibmq_backends = provider.backends()
 
 print("Remote backends: ", ibmq_backends)
 # Compile and run the Quantum Program on a real device backend
+# select those with at least 2 qubits
 try:
-    least_busy_device = least_busy(provider.backends(simulator=False))
+    least_busy_device = least_busy(provider.backends(
+        filters=lambda x: x.configuration().n_qubits >= 2, simulator=False))
 except:
     print("All devices are currently unavailable.")
 

--- a/qiskit/circuit/library/standard_gates/__init__.py
+++ b/qiskit/circuit/library/standard_gates/__init__.py
@@ -32,7 +32,6 @@ Standard gates (:mod:`qiskit.circuit.library.standard_gates`)
    CU1Gate
    CU3Gate
    C3SqrtXGate
-   C3RXGate
    CXGate
    CYGate
    CZGate
@@ -82,7 +81,7 @@ from .t import TGate, TdgGate
 from .u1 import U1Gate, CU1Gate, MCU1Gate
 from .u2 import U2Gate
 from .u3 import U3Gate, CU3Gate
-from .x import XGate, CXGate, CCXGate, C3XGate, C4XGate, RCCXGate, RC3XGate, C3SqrtXGate, C3RXGate
+from .x import XGate, CXGate, CCXGate, C3XGate, C4XGate, RCCXGate, RC3XGate, C3SqrtXGate
 from .x import MCXGate, MCXGrayCode, MCXRecursive, MCXVChain
 from .y import YGate, CYGate
 from .z import ZGate, CZGate

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -18,7 +18,6 @@ import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.circuit._utils import _compute_control_matrix
 from qiskit.qasm import pi
 from .t import TGate, TdgGate
 from .s import SGate, SdgGate
@@ -153,6 +152,18 @@ class CHGate(ControlledGate):
                 \end{pmatrix}
 
     """
+    # Define class constants. This saves future allocation time.
+    _sqrt2o2 = 1 / numpy.sqrt(2)
+    _matrix1 = numpy.array([[1, 0, 0, 0],
+                            [0, _sqrt2o2, 0, _sqrt2o2],
+                            [0, 0, 1, 0],
+                            [0, _sqrt2o2, 0, -_sqrt2o2]],
+                           dtype=complex)
+    _matrix0 = numpy.array([[_sqrt2o2, 0, _sqrt2o2, 0],
+                            [0, 1, 0, 0],
+                            [_sqrt2o2, 0, -_sqrt2o2, 0],
+                            [0, 0, 0, 1]],
+                           dtype=complex)
 
     def __init__(self, label=None, ctrl_state=None):
         """Create new CH gate."""
@@ -194,6 +205,7 @@ class CHGate(ControlledGate):
 
     def to_matrix(self):
         """Return a numpy.array for the CH gate."""
-        return _compute_control_matrix(self.base_gate.to_matrix(),
-                                       self.num_ctrl_qubits,
-                                       ctrl_state=self.ctrl_state)
+        if self.ctrl_state:
+            return self._matrix1
+        else:
+            return self._matrix0

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -18,7 +18,6 @@ import numpy
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.circuit._utils import _compute_control_matrix
 
 
 class SwapGate(Gate):
@@ -187,6 +186,23 @@ class CSwapGate(ControlledGate, metaclass=CSwapMeta):
         |0, b, c\rangle \rightarrow |0, b, c\rangle
         |1, b, c\rangle \rightarrow |1, c, b\rangle
     """
+    # Define class constants. This saves future allocation time.
+    _matrix1 = numpy.array([[1, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 1]], dtype=complex)
+    _matrix0 = numpy.array([[1, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 1, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 1]], dtype=complex)
 
     def __init__(self, label=None, ctrl_state=None):
         """Create new CSWAP gate."""
@@ -220,9 +236,10 @@ class CSwapGate(ControlledGate, metaclass=CSwapMeta):
 
     def to_matrix(self):
         """Return a numpy.array for the Fredkin (CSWAP) gate."""
-        return _compute_control_matrix(self.base_gate.to_matrix(),
-                                       self.num_ctrl_qubits,
-                                       ctrl_state=self.ctrl_state)
+        if self.ctrl_state:
+            return self._matrix1
+        else:
+            return self._matrix0
 
 
 class FredkinGate(CSwapGate, metaclass=CSwapMeta):

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -19,7 +19,6 @@ from qiskit.qasm import pi
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.circuit._utils import _compute_control_matrix
 
 
 class YGate(Gate):
@@ -172,6 +171,15 @@ class CYGate(ControlledGate, metaclass=CYMeta):
                 \end{pmatrix}
 
     """
+    # Define class constants. This saves future allocation time.
+    _matrix1 = numpy.array([[1, 0, 0, 0],
+                            [0, 0, 0, -1j],
+                            [0, 0, 1, 0],
+                            [0, 1j, 0, 0]], dtype=complex)
+    _matrix0 = numpy.array([[0, 0, -1j, 0],
+                            [0, 1, 0, 0],
+                            [1j, 0, 0, 0],
+                            [0, 0, 0, 1]], dtype=complex)
 
     def __init__(self, label=None, ctrl_state=None):
         """Create new CY gate."""
@@ -202,9 +210,10 @@ class CYGate(ControlledGate, metaclass=CYMeta):
 
     def to_matrix(self):
         """Return a numpy.array for the CY gate."""
-        return _compute_control_matrix(self.base_gate.to_matrix(),
-                                       self.num_ctrl_qubits,
-                                       ctrl_state=self.ctrl_state)
+        if self.ctrl_state:
+            return self._matrix1
+        else:
+            return self._matrix0
 
 
 class CyGate(CYGate, metaclass=CYMeta):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -276,6 +276,27 @@ class QuantumCircuit:
             inverse_circ._append(inst.inverse(), qargs, cargs)
         return inverse_circ
 
+    def repeat(self, reps):
+        """Repeat this circuit ``reps`` times.
+
+        Args:
+            reps (int): How often this circuit should be repeated.
+
+        Returns:
+            QuantumCircuit: A circuit containing ``reps`` repetitions of this circuit.
+        """
+        repeated_circ = QuantumCircuit(*self.qregs, *self.cregs,
+                                       name=self.name + '**{}'.format(reps))
+
+        # benefit of appending instructions: decomposing shows the subparts, i.e. the power
+        # is actually `reps` times this circuit, and it is currently much faster than `compose`.
+        if reps > 0:
+            inst = self.to_instruction()
+            for _ in range(reps):
+                repeated_circ.append(inst, self.qubits, self.clbits)
+
+        return repeated_circ
+
     def combine(self, rhs):
         """Append rhs to self if self contains compatible registers.
 
@@ -1581,27 +1602,27 @@ class QuantumCircuit:
 
     @deprecate_arguments({'q': 'qubit'})
     def h(self, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.HGate`."""
+        """Apply :class:`~qiskit.circuit.library.HGate`."""
         from .library.standard_gates.h import HGate
         return self.append(HGate(), [qubit], [])
 
     @deprecate_arguments({'ctl': 'control_qubit', 'tgt': 'target_qubit'})
     def ch(self, control_qubit, target_qubit,  # pylint: disable=invalid-name
            *, label=None, ctrl_state=None, ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CHGate`."""
+        """Apply :class:`~qiskit.circuit.library.CHGate`."""
         from .library.standard_gates.h import CHGate
         return self.append(CHGate(label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def i(self, qubit, *, q=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.IGate`."""
+        """Apply :class:`~qiskit.circuit.library.IGate`."""
         from .library.standard_gates.i import IGate
         return self.append(IGate(), [qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def id(self, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.IGate`."""
+        """Apply :class:`~qiskit.circuit.library.IGate`."""
         return self.i(qubit)
 
     @deprecate_arguments({'q': 'qubit'})
@@ -1614,23 +1635,23 @@ class QuantumCircuit:
         return self.i(qubit)
 
     def ms(self, theta, qubits):  # pylint: disable=invalid-name
-        """Apply :class:`~qiskit.circuit.library.standard_gates.MSGate`."""
+        """Apply :class:`~qiskit.circuit.library.MSGate`."""
         from .library.standard_gates.ms import MSGate
         return self.append(MSGate(len(qubits), theta), qubits)
 
     @deprecate_arguments({'q': 'qubit'})
     def r(self, theta, phi, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RGate`."""
+        """Apply :class:`~qiskit.circuit.library.RGate`."""
         from .library.standard_gates.r import RGate
         return self.append(RGate(theta, phi), [qubit], [])
 
     def rccx(self, control_qubit1, control_qubit2, target_qubit):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RCCXGate`."""
+        """Apply :class:`~qiskit.circuit.library.RCCXGate`."""
         from .library.standard_gates.x import RCCXGate
         return self.append(RCCXGate(), [control_qubit1, control_qubit2, target_qubit], [])
 
     def rcccx(self, control_qubit1, control_qubit2, control_qubit3, target_qubit):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RC3XGate`."""
+        """Apply :class:`~qiskit.circuit.library.RC3XGate`."""
         from .library.standard_gates.x import RC3XGate
         return self.append(RC3XGate(),
                            [control_qubit1, control_qubit2, control_qubit3, target_qubit],
@@ -1639,7 +1660,7 @@ class QuantumCircuit:
     @deprecate_arguments({'q': 'qubit'})
     # pylint: disable=invalid-name,unused-argument
     def rx(self, theta, qubit, *, label=None, q=None):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RXGate`."""
+        """Apply :class:`~qiskit.circuit.library.RXGate`."""
         from .library.standard_gates.rx import RXGate
         return self.append(RXGate(theta, label=label), [qubit], [])
 
@@ -1647,20 +1668,20 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def crx(self, theta, control_qubit, target_qubit, *, label=None, ctrl_state=None,
             ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CRXGate`."""
+        """Apply :class:`~qiskit.circuit.library.CRXGate`."""
         from .library.standard_gates.rx import CRXGate
         return self.append(CRXGate(theta, label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])
 
     def rxx(self, theta, qubit1, qubit2):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RXXGate`."""
+        """Apply :class:`~qiskit.circuit.library.RXXGate`."""
         from .library.standard_gates.rxx import RXXGate
         return self.append(RXXGate(theta), [qubit1, qubit2], [])
 
     # pylint: disable=invalid-name,unused-argument
     @deprecate_arguments({'q': 'qubit'})
     def ry(self, theta, qubit, *, label=None, q=None):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RYGate`."""
+        """Apply :class:`~qiskit.circuit.library.RYGate`."""
         from .library.standard_gates.ry import RYGate
         return self.append(RYGate(theta, label=label), [qubit], [])
 
@@ -1668,59 +1689,59 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def cry(self, theta, control_qubit, target_qubit, *, label=None, ctrl_state=None,
             ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CRYGate`."""
+        """Apply :class:`~qiskit.circuit.library.CRYGate`."""
         from .library.standard_gates.ry import CRYGate
         return self.append(CRYGate(theta, label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])
 
     def ryy(self, theta, qubit1, qubit2):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RYYGate`."""
+        """Apply :class:`~qiskit.circuit.library.RYYGate`."""
         from .library.standard_gates.ryy import RYYGate
         return self.append(RYYGate(theta), [qubit1, qubit2], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def rz(self, phi, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RZGate`."""
+        """Apply :class:`~qiskit.circuit.library.RZGate`."""
         from .library.standard_gates.rz import RZGate
         return self.append(RZGate(phi), [qubit], [])
 
     @deprecate_arguments({'ctl': 'control_qubit', 'tgt': 'target_qubit'})
     def crz(self, theta, control_qubit, target_qubit, *, label=None, ctrl_state=None,
             ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CRZGate`."""
+        """Apply :class:`~qiskit.circuit.library.CRZGate`."""
         from .library.standard_gates.rz import CRZGate
         return self.append(CRZGate(theta, label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])
 
     def rzx(self, theta, qubit1, qubit2):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RZXGate`."""
+        """Apply :class:`~qiskit.circuit.library.RZXGate`."""
         from .library.standard_gates.rzx import RZXGate
         return self.append(RZXGate(theta), [qubit1, qubit2], [])
 
     def rzz(self, theta, qubit1, qubit2):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.RZZGate`."""
+        """Apply :class:`~qiskit.circuit.library.RZZGate`."""
         from .library.standard_gates.rzz import RZZGate
         return self.append(RZZGate(theta), [qubit1, qubit2], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def s(self, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.SGate`."""
+        """Apply :class:`~qiskit.circuit.library.SGate`."""
         from .library.standard_gates.s import SGate
         return self.append(SGate(), [qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def sdg(self, qubit, *, q=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.SdgGate`."""
+        """Apply :class:`~qiskit.circuit.library.SdgGate`."""
         from .library.standard_gates.s import SdgGate
         return self.append(SdgGate(), [qubit], [])
 
     def swap(self, qubit1, qubit2):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.SwapGate`."""
+        """Apply :class:`~qiskit.circuit.library.SwapGate`."""
         from .library.standard_gates.swap import SwapGate
         return self.append(SwapGate(), [qubit1, qubit2], [])
 
     def iswap(self, qubit1, qubit2):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.iSwapGate`."""
+        """Apply :class:`~qiskit.circuit.library.iSwapGate`."""
         from .library.standard_gates.iswap import iSwapGate
         return self.append(iSwapGate(), [qubit1, qubit2], [])
 
@@ -1729,7 +1750,7 @@ class QuantumCircuit:
                           'tgt2': 'target_qubit2'})
     def cswap(self, control_qubit, target_qubit1, target_qubit2, *, label=None, ctrl_state=None,
               ctl=None, tgt1=None, tgt2=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CSwapGate`."""
+        """Apply :class:`~qiskit.circuit.library.CSwapGate`."""
         from .library.standard_gates.swap import CSwapGate
         return self.append(CSwapGate(label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit1, target_qubit2], [])
@@ -1739,24 +1760,24 @@ class QuantumCircuit:
                           'tgt2': 'target_qubit2'})
     def fredkin(self, control_qubit, target_qubit1, target_qubit2,
                 *, ctl=None, tgt1=None, tgt2=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CSwapGate`."""
+        """Apply :class:`~qiskit.circuit.library.CSwapGate`."""
         return self.cswap(control_qubit, target_qubit1, target_qubit2)
 
     @deprecate_arguments({'q': 'qubit'})
     def t(self, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.TGate`."""
+        """Apply :class:`~qiskit.circuit.library.TGate`."""
         from .library.standard_gates.t import TGate
         return self.append(TGate(), [qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def tdg(self, qubit, *, q=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.TdgGate`."""
+        """Apply :class:`~qiskit.circuit.library.TdgGate`."""
         from .library.standard_gates.t import TdgGate
         return self.append(TdgGate(), [qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def u1(self, theta, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.U1Gate`."""
+        """Apply :class:`~qiskit.circuit.library.U1Gate`."""
         from .library.standard_gates.u1 import U1Gate
         return self.append(U1Gate(theta), [qubit], [])
 
@@ -1764,26 +1785,26 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def cu1(self, theta, control_qubit, target_qubit, *, label=None, ctrl_state=None,
             ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CU1Gate`."""
+        """Apply :class:`~qiskit.circuit.library.CU1Gate`."""
         from .library.standard_gates.u1 import CU1Gate
         return self.append(CU1Gate(theta, label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])
 
     def mcu1(self, lam, control_qubits, target_qubit):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CU1Gate`."""
+        """Apply :class:`~qiskit.circuit.library.MCU1Gate`."""
         from .library.standard_gates.u1 import MCU1Gate
         num_ctrl_qubits = len(control_qubits)
         return self.append(MCU1Gate(lam, num_ctrl_qubits), control_qubits[:] + [target_qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def u2(self, phi, lam, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.U2Gate`."""
+        """Apply :class:`~qiskit.circuit.library.U2Gate`."""
         from .library.standard_gates.u2 import U2Gate
         return self.append(U2Gate(phi, lam), [qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def u3(self, theta, phi, lam, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.U3Gate`."""
+        """Apply :class:`~qiskit.circuit.library.U3Gate`."""
         from .library.standard_gates.u3 import U3Gate
         return self.append(U3Gate(theta, phi, lam), [qubit], [])
 
@@ -1791,14 +1812,14 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def cu3(self, theta, phi, lam, control_qubit, target_qubit, *, label=None, ctrl_state=None,
             ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CU3Gate`."""
+        """Apply :class:`~qiskit.circuit.library.CU3Gate`."""
         from .library.standard_gates.u3 import CU3Gate
         return self.append(CU3Gate(theta, phi, lam, label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def x(self, qubit, *, label=None, ctrl_state=None, q=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.XGate`."""
+        """Apply :class:`~qiskit.circuit.library.XGate`."""
         from .library.standard_gates.x import XGate
         return self.append(XGate(label=label), [qubit], [])
 
@@ -1806,7 +1827,7 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def cx(self, control_qubit, target_qubit, *, label=None, ctrl_state=None,
            ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CXGate`."""
+        """Apply :class:`~qiskit.circuit.library.CXGate`."""
         from .library.standard_gates.x import CXGate
         return self.append(CXGate(label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])
@@ -1815,11 +1836,11 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def cnot(self, control_qubit, target_qubit, *, label=None, ctrl_state=None,
              ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CXGate`."""
+        """Apply :class:`~qiskit.circuit.library.CXGate`."""
         self.cx(control_qubit, target_qubit, ctl=ctl, tgt=tgt)
 
     def dcx(self, qubit1, qubit2):
-        """Apply :class:`~qiskit.circuit.gate.DCXGate`."""
+        """Apply :class:`~qiskit.circuit.library.DCXGate`."""
         from .library.standard_gates.dcx import DCXGate
         return self.append(DCXGate(), [qubit1, qubit2], [])
 
@@ -1828,7 +1849,7 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def ccx(self, control_qubit1, control_qubit2, target_qubit,
             *, ctl1=None, ctl2=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CCXGate`."""
+        """Apply :class:`~qiskit.circuit.library.CCXGate`."""
         from .library.standard_gates.x import CCXGate
         return self.append(CCXGate(),
                            [control_qubit1, control_qubit2, target_qubit], [])
@@ -1838,11 +1859,11 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def toffoli(self, control_qubit1, control_qubit2, target_qubit,
                 *, ctl1=None, ctl2=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CCXGate`."""
+        """Apply :class:`~qiskit.circuit.library.CCXGate`."""
         self.ccx(control_qubit1, control_qubit2, target_qubit)
 
     def mcx(self, control_qubits, target_qubit, ancilla_qubits=None, mode='noancilla'):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.MCXGate`.
+        """Apply :class:`~qiskit.circuit.library.MCXGate`.
 
         The multi-cX gate can be implemented using different techniques, which use different numbers
         of ancilla qubits and have varying circuit depth. These modes are:
@@ -1897,12 +1918,12 @@ class QuantumCircuit:
         return self.append(gate, control_qubits[:] + [target_qubit] + ancilla_qubits[:], [])
 
     def mct(self, control_qubits, target_qubit, ancilla_qubits=None, mode='noancilla'):
-        """Apply :class:`~qiskit.circuit.library.standard_gates.MCXGate`."""
+        """Apply :class:`~qiskit.circuit.library.MCXGate`."""
         return self.mcx(control_qubits, target_qubit, ancilla_qubits, mode)
 
     @deprecate_arguments({'q': 'qubit'})
     def y(self, qubit, *, q=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.YGate`."""
+        """Apply :class:`~qiskit.circuit.library.YGate`."""
         from .library.standard_gates.y import YGate
         return self.append(YGate(), [qubit], [])
 
@@ -1910,14 +1931,14 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def cy(self, control_qubit, target_qubit, *, label=None, ctrl_state=None,
            ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CYGate`."""
+        """Apply :class:`~qiskit.circuit.library.CYGate`."""
         from .library.standard_gates.y import CYGate
         return self.append(CYGate(label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
     def z(self, qubit, *, q=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.ZGate`."""
+        """Apply :class:`~qiskit.circuit.library.ZGate`."""
         from .library.standard_gates.z import ZGate
         return self.append(ZGate(), [qubit], [])
 
@@ -1925,7 +1946,7 @@ class QuantumCircuit:
                           'tgt': 'target_qubit'})
     def cz(self, control_qubit, target_qubit, *, label=None, ctrl_state=None,
            ctl=None, tgt=None):  # pylint: disable=unused-argument
-        """Apply :class:`~qiskit.circuit.library.standard_gates.CZGate`."""
+        """Apply :class:`~qiskit.circuit.library.CZGate`."""
         from .library.standard_gates.z import CZGate
         return self.append(CZGate(label=label, ctrl_state=ctrl_state),
                            [control_qubit, target_qubit], [])

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -16,7 +16,6 @@
 
 """Model and schema for pulse defaults."""
 import copy
-import warnings
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
@@ -276,13 +275,6 @@ class PulseDefaults(SimpleNamespace):
         return (self.__class__, (self.qubit_freq_est, self.meas_freq_est,
                                  self.buffer, self.pulse_library,
                                  self.cmd_def))
-
-    @property
-    def circuit_instruction_map(self):
-        """Deprecated property, use ``instruction_schedule_map`` instead."""
-        warnings.warn("The `circuit_instruction_map` attribute has been renamed to "
-                      "`instruction_schedule_map`.", DeprecationWarning)
-        return self.instruction_schedule_map
 
     def __str__(self):
         qubit_freqs = [freq / 1e9 for freq in self.qubit_freq_est]

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -59,7 +59,7 @@ def euler_angles_1q(unitary_matrix):
     Raises:
         QiskitError: if unitary_matrix not 2x2, or failure
     """
-    warnings.warn("euler_angles_q1` is deprecated. "
+    warnings.warn("euler_angles_1q` is deprecated. "
                   "Use `synthesis.OneQubitEulerDecomposer().angles instead.",
                   DeprecationWarning)
     if unitary_matrix.shape != (2, 2):

--- a/releasenotes/notes/circuit-repeat-8db21ef8d8c21cda.yaml
+++ b/releasenotes/notes/circuit-repeat-8db21ef8d8c21cda.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a ``QuantumCircuit.repeat`` method, which returns a new circuit object containing
+    a specified number of repetitions of the original circuit. The parameters are copied by
+    reference.

--- a/releasenotes/notes/remove-circuit-instruction-map-37fb34c3b5fe033c.yaml
+++ b/releasenotes/notes/remove-circuit-instruction-map-37fb34c3b5fe033c.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    Removed ``circuit_instruction_map`` attribute from ``PulseDefaults`` which
+    had been deprecated and replaced with ``instruction_schedule_map`` in
+    Terra release 0.12.0.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -370,6 +370,29 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertEqual(qc.mirror(), expected)
 
+    def test_repeat(self):
+        """Test repeating the circuit works."""
+        qr = QuantumRegister(2)
+        cr = ClassicalRegister(2)
+        qc = QuantumCircuit(qr, cr)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.barrier()
+        qc.h(0).c_if(cr, 1)
+
+        with self.subTest('repeat 0 times'):
+            rep = qc.repeat(0)
+            self.assertEqual(rep, QuantumCircuit(qr, cr))
+
+        with self.subTest('repeat 3 times'):
+            inst = qc.to_instruction()
+            ref = QuantumCircuit(qr, cr)
+            for _ in range(3):
+                ref.append(inst, ref.qubits, ref.clbits)
+
+            rep = qc.repeat(3)
+            self.assertEqual(rep, ref)
+
 
 class TestCircuitBuilding(QiskitTestCase):
     """QuantumCircuit tests."""

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -40,7 +40,7 @@ from qiskit.circuit.library.standard_gates import (CXGate, XGate, YGate, ZGate, 
                                                    U3Gate, CHGate, CRZGate, CU3Gate,
                                                    MSGate, RCCXGate, RC3XGate,
                                                    MCU1Gate, MCXGate, MCXGrayCode, MCXRecursive,
-                                                   MCXVChain, C3XGate, C4XGate, C3RXGate)
+                                                   MCXVChain, C3XGate, C4XGate)
 from qiskit.circuit._utils import _compute_control_matrix
 import qiskit.circuit.library.standard_gates as allGates
 
@@ -875,8 +875,6 @@ class TestControlledStandardGates(QiskitTestCase):
             args[1] = 2
         elif issubclass(gate_class, MCXGate):
             args = [5]
-        elif gate_class in [C3RXGate]:
-            args = [theta]
 
         gate = gate_class(*args)
         for ctrl_state in {ctrl_state_ones, ctrl_state_zeros, ctrl_state_mixed}:
@@ -1042,20 +1040,6 @@ class TestControlledGateLabel(QiskitTestCase):
         cgate = gate(*args, label='a gate').control(1, label='a controlled gate')
         self.assertEqual(cgate.label, 'a controlled gate')
         self.assertEqual(cgate.base_gate.label, 'a gate')
-
-
-class Test3ControlledRXGate(QiskitTestCase):
-    """Tests for 3-qubit controlled RX gate equivalences."""
-
-    def test_cccxgate(self):
-        """Test C3RXGate(np.pi/4)=C3XGate()"""
-        ccc_x_gate = C3RXGate(np.pi / 4)
-        self.assertIsInstance(ccc_x_gate, allGates.C3XGate)
-
-    def test_cccsqrtxgate(self):
-        """Test C3RXGate(np.pi/8)=C3SqrtXGate()"""
-        ccc_sqrt_x_gate = C3RXGate(np.pi / 8)
-        self.assertIsInstance(ccc_sqrt_x_gate, allGates.C3SqrtXGate)
 
 
 if __name__ == '__main__':

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -30,7 +30,8 @@ from qiskit.circuit.library import (BlueprintCircuit, Permutation, QuantumVolume
                                     IntegerComparator, PiecewiseLinearPauliRotations,
                                     WeightedAdder, Diagonal, NLocal, TwoLocal, RealAmplitudes,
                                     EfficientSU2, ExcitationPreserving, PauliFeatureMap,
-                                    ZFeatureMap, ZZFeatureMap, MCMT, MCMTVChain, GMS)
+                                    ZFeatureMap, ZZFeatureMap, MCMT, MCMTVChain, GMS,
+                                    HiddenLinearFunction)
 from qiskit.circuit.random.utils import random_circuit
 from qiskit.converters.circuit_to_dag import circuit_to_dag
 from qiskit.exceptions import QiskitError
@@ -141,6 +142,46 @@ class TestPermutationLibrary(QiskitTestCase):
     def test_permutation_bad(self):
         """Test that [0,..,n-1] permutation is required (no -1 for last element)."""
         self.assertRaises(CircuitError, Permutation, 4, [1, 0, -1, 2])
+
+
+@ddt
+class TestHiddenLinearFunctionLibrary(QiskitTestCase):
+    """Test library of Hidden Linear Function circuits."""
+    def assertHLFIsCorrect(self, hidden_function, hlf):
+        """Assert that the HLF circuit produces the correct matrix.
+
+        Number of qubits is equal to the number of rows (or number of columns)
+        of hidden_function.
+        """
+        num_qubits = len(hidden_function)
+        hidden_function = np.asarray(hidden_function)
+        simulated = Operator(hlf)
+
+        expected = np.zeros((2**num_qubits, 2**num_qubits), dtype=complex)
+        for i in range(2**num_qubits):
+            i_qiskit = int(bin(i)[2:].zfill(num_qubits)[::-1], 2)
+            x_vec = np.asarray(list(map(int, bin(i)[2:].zfill(num_qubits)[::-1])))
+            expected[i_qiskit, i_qiskit] = 1j**(np.dot(x_vec.transpose(),
+                                                       np.dot(hidden_function, x_vec)))
+
+        qc = QuantumCircuit(num_qubits)
+        qc.h(range(num_qubits))
+        qc = Operator(qc)
+        expected = qc.compose(Operator(expected)).compose(qc)
+        self.assertTrue(expected.equiv(simulated))
+
+    @data(
+        [[1, 1, 0], [1, 0, 1], [0, 1, 1]]
+    )
+    def test_hlf(self, hidden_function):
+        """Test if the HLF matrix produces the right matrix."""
+        hlf = HiddenLinearFunction(hidden_function)
+        self.assertHLFIsCorrect(hidden_function, hlf)
+
+    def test_non_symmetric_raises(self):
+        """Test that adjacency matrix is required to be symmetric."""
+        with self.assertRaises(CircuitError):
+            HiddenLinearFunction([[1, 1, 0], [1, 0, 1], [1, 1, 1]])
 
 
 class TestIQPLibrary(QiskitTestCase):

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -742,6 +742,15 @@ class TestParameters(QiskitTestCase):
         inv_instr = qc.inverse().to_instruction()
         self.assertIsInstance(inv_instr, Instruction)
 
+    def test_repeated_circuit(self):
+        """Test repeating a circuit maintains the parameters."""
+        qc = QuantumCircuit(1)
+        theta = Parameter('theta')
+        qc.rz(theta, 0)
+        rep = qc.repeat(3)
+
+        self.assertEqual(rep.parameters, {theta})
+
     def test_copy_after_inverse(self):
         """Verify circuit.inverse generates a valid ParameterTable."""
         qc = QuantumCircuit(1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Remove `C3RX`, add `U = V^4` decomposition function.

### Details and comments

Instead of having a function that computes the definition of `CU` we could also wrap it into a gate. But I don't really see the need for a Gate object here since this is probably not used by any user and just internally for getting the definitions of some 3-controlled gates. Another possible location would be synthesis? Feel free to move it around!


