### PR TITLE
Move to visitor pattern for AST printer

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -188,7 +188,31 @@ class CXGate(ControlledGate):
         super().__init__(
             "cx", 2, [], num_ctrl_qubits=1, label=label, ctrl_state=ctrl_state, base_gate=XGate()
         )
-        self._qasm3_definition = "gate cx c, t {ctrl @ U(pi, 0, pi) c, t}\n"
+
+    def _define_qasm3(self):
+        from qiskit.qasm3.ast import (
+            Constant,
+            Identifier,
+            Integer,
+            QuantumBlock,
+            QuantumGateModifier,
+            QuantumGateModifierName,
+            QuantumGateSignature,
+            QuantumGateDefinition,
+            QuantumGateCall,
+        )
+
+        control, target = Identifier("c"), Identifier("t")
+        call = QuantumGateCall(
+            Identifier("U"),
+            [control, target],
+            parameters=[Constant.pi, Integer(0), Constant.pi],
+            modifiers=[QuantumGateModifier(QuantumGateModifierName.ctrl)],
+        )
+        return QuantumGateDefinition(
+            QuantumGateSignature(Identifier("cx"), [control, target]),
+            QuantumBlock([call]),
+        )
 
     def control(
         self,

--- a/qiskit/qasm3/__init__.py
+++ b/qiskit/qasm3/__init__.py
@@ -11,36 +11,55 @@
 # that they have been altered from the originals.
 
 """
-=========================
+==========================
 Qasm (:mod:`qiskit.qasm3`)
-=========================
+==========================
 
 .. currentmodule:: qiskit.qasm3
 
+.. autosummary::
+    :toctree: ../stubs/
+
+    Exporter
+    dumps
+    dump
 """
 
 from .exporter import Exporter
 
 
-def dumps(quantumcircuit):
-    """Serializes a :class:`~qiskit.circuit.QuantumCircuit` object in an OpenQASM3 string.
+def dumps(circuit, **kwargs):
+    """Serialize a :class:`~qiskit.circuit.QuantumCircuit` object in an OpenQASM3 string.
+
+    .. note::
+
+        This is a quick interface to the main :obj:`.Exporter` interface.  All keyword arguments to
+        this function are inherited from the constructor of that class, and if you have multiple
+        circuits to export, it will be faster to create an :obj:`.Exporter` instance, and use its
+        :obj:`.Exporter.dumps` method.
 
     Args:
-        quantumcircuit (QuantumCircuit): Circuit to serialize.
+        circuit (QuantumCircuit): Circuit to serialize.
 
     Returns:
         str: The OpenQASM3 serialization
     """
-    exporter = Exporter()
-    return exporter.dumps(quantumcircuit)
+    return Exporter(**kwargs).dumps(circuit)
 
 
-def dump(quantumcircuit, flo):
-    """Serializes a :class:`~qiskit.circuit.QuantumCircuit` object as a OpenQASM3 stream to file-like
-    object (a .write()-supporting object).
+def dump(circuit, stream, **kwargs):
+    """Serialize a :class:`~qiskit.circuit.QuantumCircuit` object as a OpenQASM3 stream to file-like
+    object.
+
+    .. note::
+
+        This is a quick interface to the main :obj:`.Exporter` interface.  All keyword arguments to
+        this function are inherited from the constructor of that class, and if you have multiple
+        circuits to export, it will be faster to create an :obj:`.Exporter` instance, and use its
+        :obj:`.Exporter.dump` method.
 
     Args:
-        quantumcircuit (QuantumCircuit): Circuit to serialize.
-        flo (TextIOBase): file-like object to dump the OpenQASM3 serialization
+        circuit (QuantumCircuit): Circuit to serialize.
+        stream (TextIOBase): stream-like object to dump the OpenQASM3 serialization
     """
-    Exporter().dump(quantumcircuit, flo)
+    return Exporter(**kwargs).dump(circuit, stream)

--- a/qiskit/qasm3/printer.py
+++ b/qiskit/qasm3/printer.py
@@ -1,0 +1,360 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Printers for QASM 3 AST nodes."""
+
+import io
+from typing import Sequence
+
+from .ast import (
+    ASTNode,
+    AliasStatement,
+    BitDeclaration,
+    BranchingStatement,
+    CalibrationDefinition,
+    CalibrationGrammarDeclaration,
+    ComparisonExpression,
+    Constant,
+    Designator,
+    EqualsOperator,
+    Expression,
+    GtOperator,
+    Header,
+    IO,
+    IOModifier,
+    Identifier,
+    Include,
+    IndexIdentifier2,
+    Integer,
+    LtOperator,
+    PhysicalQubitIdentifier,
+    Pragma,
+    Program,
+    ProgramBlock,
+    QuantumArgument,
+    QuantumBarrier,
+    QuantumDeclaration,
+    QuantumGateCall,
+    QuantumGateDefinition,
+    QuantumGateModifier,
+    QuantumGateModifierName,
+    QuantumGateSignature,
+    QuantumMeasurement,
+    QuantumMeasurementAssignment,
+    ReturnStatement,
+    SubroutineCall,
+    SubroutineDefinition,
+    Version,
+)
+
+
+class BasicPrinter:
+    """A QASM 3 AST visitor which writes the tree out in text mode to a stream, where the only
+    formatting is simple block indentation."""
+
+    _CONSTANT_LOOKUP = {
+        Constant.pi: "pi",
+        Constant.euler: "euler",
+        Constant.tau: "tau",
+    }
+
+    _MODIFIER_LOOKUP = {
+        QuantumGateModifierName.ctrl: "ctrl",
+        QuantumGateModifierName.negctrl: "negctrl",
+        QuantumGateModifierName.inv: "inv",
+        QuantumGateModifierName.pow: "pow",
+    }
+
+    # The visitor names include the class names, so they mix snake_case with PascalCase.
+    # pylint: disable=invalid-name
+
+    def __init__(self, stream: io.TextIOBase, *, indent: str):
+        """
+        Args:
+            stream (io.TextIOBase): the stream that the output will be written to.
+            indent (str): the string to use as a single indentation level.
+        """
+        self.stream = stream
+        self.indent = indent
+        self._current_indent = 0
+
+    def visit(self, node: ASTNode) -> None:
+        """Visit this node of the AST, printing it out to the stream in this class instance.
+
+        Normally, you will want to call this function on a complete :obj:`~qiskit.qasm3.ast.Program`
+        node, to print out a complete program to the stream.  The visit can start from any node,
+        however, if you want to build up a file bit-by-bit manually.
+
+        Args:
+            node (ASTNode): the node to convert to QASM 3 and write out to the stream.
+
+        Raises:
+            RuntimeError: if an AST node is encountered that the visitor is unable to parse.  This
+                typically means that the given AST was malformed.
+        """
+        visitor = None
+        for cls_ in type(node).mro():
+            visitor = getattr(self, "_visit_" + cls_.__name__, None)
+            if visitor is not None:
+                break
+        else:
+            node_type = node.__class__.__name__
+            raise RuntimeError(
+                f"This visitor does not know how to handle AST nodes of type '{node_type}',"
+                f" but was given '{node}'."
+            )
+        visitor(node)
+
+    def _start_line(self) -> None:
+        self.stream.write(self._current_indent * self.indent)
+
+    def _end_statement(self) -> None:
+        self.stream.write(";\n")
+
+    def _end_line(self) -> None:
+        self.stream.write("\n")
+
+    def _write_statement(self, line: str) -> None:
+        self._start_line()
+        self.stream.write(line)
+        self._end_statement()
+
+    def _visit_sequence(
+        self, nodes: Sequence[ASTNode], *, start: str = "", end: str = "", separator: str
+    ) -> None:
+        if start:
+            self.stream.write(start)
+        for node in nodes[:-1]:
+            self.visit(node)
+            self.stream.write(separator)
+        if nodes:
+            self.visit(nodes[-1])
+        if end:
+            self.stream.write(end)
+
+    def _visit_Program(self, node: Program) -> None:
+        self.visit(node.header)
+        for statement in node.statements:
+            self.visit(statement)
+
+    def _visit_Header(self, node: Header) -> None:
+        self.visit(node.version)
+        for include in node.includes:
+            self.visit(include)
+
+    def _visit_Version(self, node: Version) -> None:
+        self._write_statement(f"OPENQASM {node.version_number}")
+
+    def _visit_Include(self, node: Include) -> None:
+        self._write_statement(f'include "{node.filename}"')
+
+    def _visit_Pragma(self, node: Pragma) -> None:
+        self._write_statement(f"#pragma {node.content}")
+
+    def _visit_CalibrationGrammarDeclaration(self, node: CalibrationGrammarDeclaration) -> None:
+        self._write_statement(f'defcalgrammar "{node.name}"')
+
+    def _visit_Identifier(self, node: Identifier) -> None:
+        self.stream.write(node.string)
+
+    def _visit_PhysicalQubitIdentifier(self, node: PhysicalQubitIdentifier) -> None:
+        self.stream.write("$")
+        self.visit(node.identifier)
+
+    def _visit_Expression(self, node: Expression) -> None:
+        self.stream.write(str(node.something))
+
+    def _visit_Constant(self, node: Constant) -> None:
+        self.stream.write(self._CONSTANT_LOOKUP[node])
+
+    def _visit_IndexIdentifier2(self, node: IndexIdentifier2) -> None:
+        self.visit(node.identifier)
+        if node.expressionList:
+            self._visit_sequence(node.expressionList, start="[", end="]", separator=", ")
+
+    def _visit_QuantumMeasurement(self, node: QuantumMeasurement) -> None:
+        self.stream.write("measure ")
+        self._visit_sequence(node.indexIdentifierList, separator=", ")
+
+    def _visit_QuantumMeasurementAssignment(self, node: QuantumMeasurementAssignment) -> None:
+        self._start_line()
+        self.visit(node.indexIdentifier)
+        self.stream.write(" = ")
+        self.visit(node.quantumMeasurement)
+        self._end_statement()
+
+    def _visit_Integer(self, node: Integer) -> None:
+        self.stream.write(str(node.something))
+
+    def _visit_Designator(self, node: Designator) -> None:
+        self.stream.write("[")
+        self.visit(node.expression)
+        self.stream.write("]")
+
+    def _visit_BitDeclaration(self, node: BitDeclaration) -> None:
+        self._start_line()
+        self.stream.write("bit")
+        self.visit(node.designator)
+        self.stream.write(" ")
+        self.visit(node.identifier)
+        if node.equalsExpression:
+            self.stream.write(" ")
+            self.visit(node.equalsExpression)
+        self._end_statement()
+
+    def _visit_QuantumDeclaration(self, node: QuantumDeclaration) -> None:
+        self._start_line()
+        self.stream.write("qubit")
+        self.visit(node.designator)
+        self.stream.write(" ")
+        self.visit(node.identifier)
+        self._end_statement()
+
+    def _visit_AliasStatement(self, node: AliasStatement) -> None:
+        self._start_line()
+        self.stream.write("let ")
+        self.visit(node.identifier)
+        self.stream.write(" = ")
+        self._visit_sequence(node.qubits, separator=" || ")
+        self._end_statement()
+
+    def _visit_QuantumGateModifier(self, node: QuantumGateModifier) -> None:
+        self.stream.write(self._MODIFIER_LOOKUP[node.modifier])
+        if node.argument:
+            self.stream.write("(")
+            self.visit(node.argument)
+            self.stream.write(")")
+
+    def _visit_QuantumGateCall(self, node: QuantumGateCall) -> None:
+        self._start_line()
+        if node.modifiers:
+            self._visit_sequence(node.modifiers, end=" @ ", separator=" @ ")
+        self.visit(node.quantumGateName)
+        if node.parameters:
+            self._visit_sequence(node.parameters, start="(", end=")", separator=", ")
+        self.stream.write(" ")
+        self._visit_sequence(node.indexIdentifierList, separator=", ")
+        self._end_statement()
+
+    def _visit_SubroutineCall(self, node: SubroutineCall) -> None:
+        self._start_line()
+        self.visit(node.identifier)
+        if node.expressionList:
+            self._visit_sequence(node.expressionList, start="(", end=")", separator=", ")
+        self.stream.write(" ")
+        self._visit_sequence(node.indexIdentifierList, separator=", ")
+        self._end_statement()
+
+    def _visit_QuantumBarrier(self, node: QuantumBarrier) -> None:
+        self._start_line()
+        self.stream.write("barrier ")
+        self._visit_sequence(node.indexIdentifierList, separator=", ")
+        self._end_statement()
+
+    def _visit_ProgramBlock(self, node: ProgramBlock) -> None:
+        self.stream.write("{\n")
+        self._current_indent += 1
+        for statement in node.statements:
+            self.visit(statement)
+        self._current_indent -= 1
+        self._start_line()
+        self.stream.write("}")
+
+    def _visit_ReturnStatement(self, node: ReturnStatement) -> None:
+        self._start_line()
+        if node.expression:
+            self.stream.write("return ")
+            self.visit(node.expression)
+        else:
+            self.stream.write("return")
+        self._end_statement()
+
+    def _visit_QuantumArgument(self, node: QuantumArgument) -> None:
+        self.stream.write("qubit")
+        if node.designator:
+            self.visit(node.designator)
+        self.stream.write(" ")
+        self.visit(node.identifier)
+
+    def _visit_QuantumGateSignature(self, node: QuantumGateSignature) -> None:
+        self.visit(node.name)
+        if node.params:
+            self._visit_sequence(node.params, start="(", end=")", separator=", ")
+        self.stream.write(" ")
+        self._visit_sequence(node.qargList, separator=", ")
+
+    def _visit_QuantumGateDefinition(self, node: QuantumGateDefinition) -> None:
+        self._start_line()
+        self.stream.write("gate ")
+        self.visit(node.quantumGateSignature)
+        self.stream.write(" ")
+        self.visit(node.quantumBlock)
+        self._end_line()
+
+    def _visit_SubroutineDefinition(self, node: SubroutineDefinition) -> None:
+        self._start_line()
+        self.stream.write("def ")
+        self.visit(node.identifier)
+        self._visit_sequence(node.arguments, start="(", end=")", separator=", ")
+        self.stream.write(" ")
+        self.visit(node.subroutineBlock)
+        self._end_line()
+
+    def _visit_CalibrationDefinition(self, node: CalibrationDefinition) -> None:
+        self._start_line()
+        self.stream.write("defcal ")
+        self.visit(node.name)
+        self.stream.write(" ")
+        if node.calibrationArgumentList:
+            self._visit_sequence(node.calibrationArgumentList, start="(", end=")", separator=", ")
+            self.stream.write(" ")
+        self._visit_sequence(node.identifierList, separator=", ")
+        # This is temporary: calibration definition blocks are not currently (2021-10-04) defined
+        # properly.
+        self.stream.write(" {}")
+        self._end_line()
+
+    def _visit_LtOperator(self, _node: LtOperator) -> None:
+        self.stream.write(">")
+
+    def _visit_GtOperator(self, _node: GtOperator) -> None:
+        self.stream.write("<")
+
+    def _visit_EqualsOperator(self, _node: EqualsOperator) -> None:
+        self.stream.write("==")
+
+    def _visit_ComparisonExpression(self, node: ComparisonExpression) -> None:
+        self.visit(node.left)
+        self.stream.write(" ")
+        self.visit(node.relation)
+        self.stream.write(" ")
+        self.visit(node.right)
+
+    def _visit_BranchingStatement(self, node: BranchingStatement) -> None:
+        self._start_line()
+        self.stream.write("if (")
+        self.visit(node.booleanExpression)
+        self.stream.write(") ")
+        self.visit(node.programTrue)
+        if node.programFalse:
+            self.stream.write(" else ")
+            self.visit(node.programFalse)
+        self._end_line()
+
+    def _visit_IO(self, node: IO) -> None:
+        self._start_line()
+        modifier = "input" if node.modifier == IOModifier.input else "output"
+        self.stream.write(modifier + " ")
+        self.visit(node.type)
+        self.stream.write(" ")
+        self.visit(node.variable)
+        self._end_statement()

--- a/test/python/circuit/test_circuit_qasm3.py
+++ b/test/python/circuit/test_circuit_qasm3.py
@@ -73,13 +73,13 @@ cr[0] = measure qr1[0];
 cr[1] = measure qr2[0];
 cr[2] = measure qr2[1];
 if (cr == 0) {
-x qr2[1];
+  x qr2[1];
 }
 if (cr == 1) {
-y qr1[0];
+  y qr1[0];
 }
 if (cr == 2) {
-z qr1[0];
+  z qr1[0];
 }
 """
         self.assertEqual(Exporter().dumps(qc), expected_qasm)
@@ -105,10 +105,9 @@ z qr1[0];
         expected_qasm = """OPENQASM 3;
 include "stdgates.inc";
 def composite_circ(qubit q_0, qubit q_1) {
-h q_0;
-x q_1;
-cx q_0, q_1;
-return;
+  h q_0;
+  x q_1;
+  cx q_0, q_1;
 }
 bit[2] cr;
 qubit[2] _q;
@@ -120,7 +119,7 @@ composite_circ qr[0], qr[1];
 cr[0] = measure qr[0];
 cr[1] = measure qr[1];
 """
-        self.assertEqual(Exporter().dumps(qc).strip(), expected_qasm)
+        self.assertEqual(Exporter().dumps(qc), expected_qasm)
 
     def test_custom_gate(self):
         """Test custom gates (via to_gate)."""
@@ -143,9 +142,9 @@ cr[1] = measure qr[1];
         expected_qasm = """OPENQASM 3;
 include "stdgates.inc";
 gate composite_circ q_0, q_1 {
-h q_0;
-x q_1;
-cx q_0, q_1;
+  h q_0;
+  x q_1;
+  cx q_0, q_1;
 }
 bit[2] cr;
 qubit[2] _q;
@@ -181,10 +180,9 @@ cr[1] = measure qr[1];
         expected_qasm = """OPENQASM 3;
 include "stdgates.inc";
 def composite_circ(qubit q_0, qubit q_1) {
-h q_0;
-x q_1;
-cx q_0, q_1;
-return;
+  h q_0;
+  x q_1;
+  cx q_0, q_1;
 }
 bit[2] cr;
 qubit[2] _q;
@@ -223,16 +221,13 @@ cr[1] = measure qr[1];
         expected_qasm = f"""OPENQASM 3;
 include "stdgates.inc";
 def my_gate(qubit q_0) {{
-h q_0;
-return;
+  h q_0;
 }}
 def my_gate_{my_gate_inst2_id}(qubit q_0) {{
-x q_0;
-return;
+  x q_0;
 }}
 def my_gate_{my_gate_inst3_id}(qubit q_0) {{
-x q_0;
-return;
+  x q_0;
 }}
 qubit[1] _q;
 let qr = _q[0];
@@ -278,7 +273,7 @@ U(6.283185307179586, 9.42477796076938, -15.707963267948966) q[0];
         expected_qasm = """OPENQASM 3;
 include "stdgates.inc";
 gate custom(a) q_0 {
-rx(a) q_0;
+  rx(a) q_0;
 }
 input float[32] a;
 qubit[1] _q;
@@ -302,7 +297,7 @@ custom(a) q[0];
         expected_qasm = """OPENQASM 3;
 include "stdgates.inc";
 gate custom q_0 {
-rx(0.5) q_0;
+  rx(0.5) q_0;
 }
 qubit[1] _q;
 let q = _q[0];
@@ -327,11 +322,11 @@ custom q[0];
         circuit.assign_parameters({parameter0: pi, parameter1: pi / 2}, inplace=True)
 
         qubit_name = circuit.data[0][0].definition.qregs[0].name
-        expected_qasm = """OPENQASM 3;
+        expected_qasm = f"""OPENQASM 3;
 include "stdgates.inc";
 gate custom(param_0, param_1) {qubit_name}_0, {qubit_name}_1 {{
-rz(pi) {qubit_name}_0;
-rz(pi/4) {qubit_name}_1;
+  rz(pi) {qubit_name}_0;
+  rz(pi/4) {qubit_name}_1;
 }}
 qubit[6] _q;
 let q = _q[0] || _q[1] || _q[2];
@@ -354,13 +349,13 @@ custom(pi, pi/2) q[0], r[0];
         circuit_name_0 = circuit.data[0][0].definition.name
         circuit_name_1 = circuit.data[1][0].definition.name
 
-        expected_qasm = """OPENQASM 3;
+        expected_qasm = f"""OPENQASM 3;
 include "stdgates.inc";
 gate {circuit_name_0} q_0 {{
-rx(0.5) q_0;
+  rx(0.5) q_0;
 }}
 gate {circuit_name_1} q_0 {{
-rx(1) q_0;
+  rx(1) q_0;
 }}
 qubit[1] _q;
 let q = _q[0];
@@ -391,9 +386,9 @@ rz(θ) q[0];
         expected_qasm = """OPENQASM 3;
 include "stdgates.inc";
 gate ch_o0 q_0, q_1 {
-x q_0;
-ch q_0, q_1;
-x q_0;
+  x q_0;
+  ch q_0, q_1;
+  x q_0;
 }
 qubit[2] _q;
 let q = _q[0] || _q[1];
@@ -410,10 +405,10 @@ ch_o0 q[0], q[1];
         qc = QuantumCircuit(2)
         qc.append(custom_gate, [0, 1])
         custom_gate_id = id(qc.data[-1][0])
-        expected_qasm = """OPENQASM 3;
+        expected_qasm = f"""OPENQASM 3;
 include "stdgates.inc";
 gate cx_{custom_gate_id} q_0, q_1 {{
-cx q_0, q_1;
+  cx q_0, q_1;
 }}
 qubit[2] _q;
 let q = _q[0] || _q[1];
@@ -433,29 +428,31 @@ cx_{custom_gate_id} q[0], q[1];
         circuit.measure(q[0], qc[0])
         circuit.measure(q[1], qc[1])
         expected_qasm = """OPENQASM 3;
-gate cx c, t {ctrl @ U(pi, 0, pi) c, t}
+gate cx c, t {
+  ctrl @ U(pi, 0, pi) c, t;
+}
 gate u3(param_0, param_1, param_2) q_0 {
-U(0, 0, pi/2) q_0;
+  U(0, 0, pi/2) q_0;
 }
 gate u1(param_0) q_0 {
-u3(0, 0, pi/2) q_0;
+  u3(0, 0, pi/2) q_0;
 }
 gate rz(param_0) q_0 {
-u1(pi/2) q_0;
+  u1(pi/2) q_0;
 }
 gate sdg q_0 {
-u1(-pi/2) q_0;
+  u1(-pi/2) q_0;
 }
 gate u2(param_0, param_1) q_0 {
-u3(pi/2, 0, pi) q_0;
+  u3(pi/2, 0, pi) q_0;
 }
 gate h q_0 {
-u2(0, pi) q_0;
+  u2(0, pi) q_0;
 }
 gate sx q_0 {
-sdg q_0;
-h q_0;
-sdg q_0;
+  sdg q_0;
+  h q_0;
+  sdg q_0;
 }
 bit[2] qc;
 qubit[5] _q;
@@ -485,24 +482,26 @@ qc[1] = measure q[1];
 
         transpiled = transpile(qc, initial_layout=[0, 1, 2])
         expected_qasm = """OPENQASM 3;
-gate cx c, t {ctrl @ U(pi, 0, pi) c, t}
+gate cx c, t {
+  ctrl @ U(pi, 0, pi) c, t;
+}
 gate u3(param_0, param_1, param_2) q_0 {
-U(pi/2, 0, pi) q_0;
+  U(pi/2, 0, pi) q_0;
 }
 gate u2(param_0, param_1) q_0 {
-u3(pi/2, 0, pi) q_0;
+  u3(pi/2, 0, pi) q_0;
 }
 gate h q_0 {
-u2(0, pi) q_0;
+  u2(0, pi) q_0;
 }
 gate x q_0 {
-u3(pi, 0, pi) q_0;
+  u3(pi, 0, pi) q_0;
 }
 gate u1(param_0) q_0 {
-u3(0, 0, pi) q_0;
+  u3(0, 0, pi) q_0;
 }
 gate z q_0 {
-u1(pi) q_0;
+  u1(pi) q_0;
 }
 bit[2] c;
 h $1;
@@ -515,10 +514,10 @@ c[0] = measure $0;
 c[1] = measure $1;
 barrier $0, $1, $2;
 if (c[1] == 1) {
-x $2;
+  x $2;
 }
 if (c[0] == 1) {
-z $2;
+  z $2;
 }
 """
         self.assertEqual(Exporter(includes=[]).dumps(transpiled), expected_qasm)
@@ -540,16 +539,16 @@ z $2;
         transpiled = transpile(qc, initial_layout=[0, 1, 2])
         expected_qasm = """OPENQASM 3;
 gate u3(param_0, param_1, param_2) q_0 {
-U(pi/2, 0, pi) q_0;
+  U(pi/2, 0, pi) q_0;
 }
 gate u2(param_0, param_1) q_0 {
-u3(pi/2, 0, pi) q_0;
+  u3(pi/2, 0, pi) q_0;
 }
 gate h q_0 {
-u2(0, pi) q_0;
+  u2(0, pi) q_0;
 }
 gate x q_0 {
-u3(pi, 0, pi) q_0;
+  u3(pi, 0, pi) q_0;
 }
 bit[2] c;
 h $1;
@@ -562,10 +561,10 @@ c[0] = measure $0;
 c[1] = measure $1;
 barrier $0, $1, $2;
 if (c[1] == 1) {
-x $2;
+  x $2;
 }
 if (c[0] == 1) {
-z $2;
+  z $2;
 }
 """
         self.assertEqual(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This fully separates out the "AST generation" step from the "conversion
to QASM" step, by moving the QASM definitions of each AST object into a
single AST visitor.  This is in anticipation of swapping the QASM 3 AST
from one defined by Terra to a reference implementation defined by the
OpenQASM team.

As a consequence, the `_qasm3_definition` attribute given to `CXGate` as
a test is changed to a method returning an AST node.  In the future, it
may be desirable to allow this function to return a string, and have
that parsed into a QASM AST node for use in the generator.  This may
become possible once the AST is removed from Terra in favour of the open
reference AST package currently in development.  Similarly, the
pretty-printer visitor may be removed from Terra once that split is
made, simplifying the code we have to take care of on our side.


### Details and comments

I'm trying to make a cleaner split between the AST and string generation, because we won't have the `ast.py` file forever, and the reference AST implementation currently doesn't come with an AST -> string step.  To ease the transition, I've written that complete step in the visitor pattern, so we're in the correct form for outputting stuff once we get that.

This is probably the first of a couple of PRs to this branch - it's a huge change, so I didn't want to just push it directly to your PR.  This one splits the AST and string generation.  Right now, that means that the only sensible way to have the `_define_qasm3` property on instructions is for them to return AST objects, but in the future, I think we could allow them to return a string, and use the reference AST's parser implementation to convert that into a proper QASM definition.

I fixed up and added a couple of AST nodes to make the thing work, but there's some more work to be done on it - I think various bits of the QASM 3 grammar have been changed since the original draft of this, so some things are a little bit out-of-date.

The next step I'd like to do is to have the `Exporter` manage includes by having it parse the given files into actual AST nodes (for now, the basic regex thing is enough) once, and then pass them on to the tree builder in that form, rather than tying the scopes to Terra objects; once we've got a _complete_ parser, that'll let us have an option for the user to verify that the gate definitions in their headers are compatible with the objects they're passing.
